### PR TITLE
Use pickle.dumps(key) as key, so any picklable object can be the key

### DIFF
--- a/tests/test_keytypes.py
+++ b/tests/test_keytypes.py
@@ -1,50 +1,40 @@
 # encoding: utf-8
-"""
-Ensure that types other than 'str' may be used as the dict key.
-
-We make use of 'Test generators' in nose,
-https://nose.readthedocs.org/en/latest/writing_tests.html#test-generators
-
-Please note that method generators are not supported in
-unittest.TestCase subclasses.
-"""
+"""Ensure different types of key, including mutable and immutable, works"""
 
 # std imports
 import unittest
 
 # local
 import sqlitedict
-from accessories import TestCaseBackport
 
-def _assert_keyvalue(given_key, given_val):
-    # given,
-    with sqlitedict.SqliteDict() as db:
-        # exercise
-        db[given_key] = given_val
-        result_key = db.keys()[0]
-        result_val = db[result_key]
-
-    # verify
-    assert type(result_key) == type(given_key), (result_key, given_key)
-    assert type(result_val) == type(given_val), (result_val, given_val)
-    assert result_key == given_key, (result_key, given_key)
-    assert result_val == given_val, (result_val, given_val)
-
-def test_strtype():
-    """ Ensure the default str-type works fine. """
-    yield _assert_keyvalue, b'some-key', b'some-val'
-
-class test_nextquery_exception(TestCaseBackport):
-
-    def test_inner_exception(self):
-        """Validates that an exception is thrown on *next* query. """
-        # per issue #25 we currently expect this to fail, it happens
-        # to provide test coverage for the exception handling, however.
-        import sqlite3
-        # given,
-        given_key, given_val = (1, 2), (3, 4)
-        with sqlitedict.SqliteDict() as db:
-            # exercise
-            db[given_key] = given_val
-            with self.assertRaises(sqlite3.InterfaceError):
-                result_key = db.keys()[0]
+class KeyTypeTest(unittest.TestCase):
+    def test_list_key(self):
+        """Use list object as key"""
+        fname = 'tests/db/sqlitedict-mutable-test.sqlite'
+        d = sqlitedict2.SqliteDict(fname, autocommit=True)
+        k1 = [1,2]
+        k2 = k1.copy()
+        d[k1] = 3
+        self.assertEqual(d[k1], 3)
+        self.assertEqual(d[k2], 3)
+        k1.append('3')
+        d[k1] = 4
+        self.assertEqual(d[k1], 4)
+        self.assertEqual(d[k2], 3)
+        
+    def test_float_tuple_key(self):
+        """Use float tuple object as key
+        
+        k1 == k2 but k1 is not k2
+        """
+        fname = 'tests/db/sqlitedict2-mutable-test.sqlite'
+        d = sqlitedict.SqliteDict(fname, autocommit=True)
+        k1 = (1.1, 2.2)
+        k2 = (1.1, 2.2)
+        self.assertIsNot(k1, k2)
+        d[k1] = 3
+        self.assertEqual(d[k1], 3)
+        self.assertEqual(d[k2], 3)
+        d[k2] = 4
+        self.assertEqual(d[k1], 4)
+        self.assertEqual(d[k2], 4)

--- a/tests/test_keytypes.py
+++ b/tests/test_keytypes.py
@@ -11,7 +11,7 @@ class KeyTypeTest(unittest.TestCase):
     def test_list_key(self):
         """Use list object as key"""
         fname = 'tests/db/sqlitedict-mutable-test.sqlite'
-        d = sqlitedict2.SqliteDict(fname, autocommit=True)
+        d = sqlitedict.SqliteDict(fname, autocommit=True)
         k1 = [1,2]
         k2 = k1.copy()
         d[k1] = 3
@@ -27,7 +27,7 @@ class KeyTypeTest(unittest.TestCase):
         
         k1 == k2 but k1 is not k2
         """
-        fname = 'tests/db/sqlitedict2-mutable-test.sqlite'
+        fname = 'tests/db/sqlitedict-mutable-test.sqlite'
         d = sqlitedict.SqliteDict(fname, autocommit=True)
         k1 = (1.1, 2.2)
         k2 = (1.1, 2.2)


### PR DESCRIPTION
Use pickle.dumps(key) as key, so any picklable object can be the key.
This would make the database files incompatible with previous version.