### PR TITLE
Fixed issue with dict iterators.

### DIFF
--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -278,9 +278,9 @@ class SqliteDict(DictClass):
 
 # Adding extra methods for python 2 compatibility (at import time)
 if major_version == 2:
-    setattr(SqliteDict, "iterkeys", lambda self: self.keys())
-    setattr(SqliteDict, "itervalues", lambda self: self.values())
-    setattr(SqliteDict, "iteritems", lambda self: self.items())
+    setattr(SqliteDict, "iterkeys", lambda self: iter(self.keys()))
+    setattr(SqliteDict, "itervalues", lambda self: iter(self.values()))
+    setattr(SqliteDict, "iteritems", lambda self: iter(self.items()))
     SqliteDict.__nonzero__ = SqliteDict.__bool__
     del SqliteDict.__bool__  # not needed and confusing
 #endclass SqliteDict


### PR DESCRIPTION
It turns out the "iteritems" method didn't return an iterator, but rather simply returned a list of the items. This problem was simple to fix once I found it.

I tried to make a SqliteDict (lets call it sdict) with a bunch of items, and then tried the following.
```
import sys
sys.getsizeof(sdict.items())  # Size of list of items object (in bytes).
sys.getsizeof(sdict.iteritems())  # Size of item iterator object (in bytes).
```
These turned out to be the same size. After I made the changes in this commit the iterator was only 64 bytes.