### PR TITLE
Fix for terminating tempfile error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ SetupDevelop.__doc__ = setuptools.command.develop.develop.__doc__
 
 setup(
     name='sqlitedict',
-    version='1.4.0',
+    version='1.4.1',
     description='Persistent dict in Python, backed up by sqlite3 and pickle, multithread-safe.',
     long_description=read('README.rst'),
 

--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -294,9 +294,9 @@ class SqliteDict(DictClass):
         if self.filename == ':memory:':
             return
 
-        logger.info("deleting %s" % self.filename)
         try:
-            os.remove(self.filename)
+            if os.path.isfile(self.filename):
+                os.remove(self.filename)
         except (OSError, IOError):
             logger.exception("failed to delete %s" % (self.filename))
 

--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -294,6 +294,7 @@ class SqliteDict(DictClass):
         if self.filename == ':memory:':
             return
 
+        logger.info("deleting %s" % self.filename)
         try:
             if os.path.isfile(self.filename):
                 os.remove(self.filename)


### PR DESCRIPTION
Hi!

Working with your excellent sqlitedict, regular debug exception occur upon terminating an index file being an instance of tempfile. I propose the following small fix to avoid any attempts to delete non-existing files. 
I'd be grateful for a quick (minor) pip release. 
Thanks for your great work!

Regards,
Adrian