### PR TITLE
Fix exit error TypeError("'NoneType' object is not callable",) using catch try block in close method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
+.cache
 
 # sqlite databases
 *.sqlite

--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -233,6 +233,9 @@ class SqliteDict(DictClass):
         self.conn.execute(ADD_ITEM, (key, encode(value)))
 
     def __delitem__(self, key):
+        if self.flag == 'r':
+            raise RuntimeError('Refusing to delete from read-only SqliteDict')
+
         if key not in self:
             raise KeyError(key)
         DEL_ITEM = 'DELETE FROM %s WHERE key = ?' % self.tablename

--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -242,6 +242,9 @@ class SqliteDict(DictClass):
         self.conn.execute(DEL_ITEM, (key,))
 
     def update(self, items=(), **kwds):
+        if self.flag == 'r':
+            raise RuntimeError('Refusing to update read-only SqliteDict')
+
         try:
             items = [(k, encode(v)) for k, v in items.items()]
         except AttributeError:
@@ -256,6 +259,9 @@ class SqliteDict(DictClass):
         return self.iterkeys()
 
     def clear(self):
+        if self.flag == 'r':
+            raise RuntimeError('Refusing to clear read-only SqliteDict')
+
         CLEAR_ALL = 'DELETE FROM %s;' % self.tablename  # avoid VACUUM, as it gives "OperationalError: database schema has changed"
         self.conn.commit()
         self.conn.execute(CLEAR_ALL)
@@ -291,6 +297,9 @@ class SqliteDict(DictClass):
                 pass
 
     def terminate(self):
+        if self.flag == 'r':
+            raise RuntimeError('Refusing to terminate read-only SqliteDict')
+
         """Delete the underlying database file. Use with care."""
         self.close()
 

--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -168,7 +168,7 @@ class SqliteDict(DictClass):
         self.close()
 
     def __str__(self):
-        return "SqliteDict(%s)" % (self.conn.filename)
+        return "SqliteDict(%s)" % (self.filename)
 
     def __repr__(self):
         return str(self)  # no need of something complex

--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -297,10 +297,10 @@ class SqliteDict(DictClass):
                 pass
 
     def terminate(self):
+        """Delete the underlying database file. Use with care."""
         if self.flag == 'r':
             raise RuntimeError('Refusing to terminate read-only SqliteDict')
 
-        """Delete the underlying database file. Use with care."""
         self.close()
 
         if self.filename == ':memory:':

--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -315,7 +315,13 @@ class SqliteDict(DictClass):
 
     def __del__(self):
         # like close(), but assume globals are gone by now (do not log!)
-        self.close(do_log=False)
+        try:
+            self.close(do_log=False)
+        except Exception:
+            # prevent error log flood in case of multiple SqliteDicts
+            # closed after connection lost (exceptions are always ignored
+            # in __del__ method.
+            pass
 
 # Adding extra methods for python 2 compatibility (at import time)
 if major_version == 2:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -106,6 +106,22 @@ class NamedSqliteDictCreateOrReuseTest(TempSqliteDictTest):
         with self.assertRaises(RuntimeError):
             attempt_write()
 
+    def test_readonly_delete(self):
+        fname = norm_file('tests/db/sqlitedict-override-test.sqlite')
+        orig_db = sqlitedict.SqliteDict(filename=fname)
+        orig_db['key'] = 'value'
+        orig_db.commit()
+        orig_db.close()
+
+        readonly_db = sqlitedict.SqliteDict(filename=fname, flag = 'r')
+        self.assertTrue(readonly_db['key'] == 'value')
+
+        def attempt_delete():
+            del readonly_db['key']
+
+        with self.assertRaises(RuntimeError):
+            attempt_delete()
+
     def test_overwrite_using_flag_w(self):
         """Re-opening of a database with flag='w' destroys only the target table."""
         # given,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -26,6 +26,9 @@ class SqliteMiscTest(TestCaseBackport):
         db = sqlitedict.SqliteDict()
         # exercise
         db.__str__()
+        # test when db closed
+        db.close()
+        db.__str__()
 
     def test_as_repr(self):
         """Verify SqliteDict.__repr__()."""


### PR DESCRIPTION
Fixes https://github.com/piskvorky/sqlitedict/issues/44

@piskvorky 
Added `try catch` block to `close` function to prevent error log message in `__del__` method when `sqlitedict` is not closed correctly. Error was raised by `conn.close()` and `conn.commit()`

