### PR TITLE
Forgot to pickle when using the update method with a sequence

### DIFF
--- a/sqlitedict.py
+++ b/sqlitedict.py
@@ -246,9 +246,10 @@ class SqliteDict(DictClass):
             raise RuntimeError('Refusing to update read-only SqliteDict')
 
         try:
-            items = [(k, encode(v)) for k, v in items.items()]
+            items = items.items()
         except AttributeError:
             pass
+        items = [(k, encode(v)) for k, v in items]
 
         UPDATE_ITEMS = 'REPLACE INTO %s (key, value) VALUES (?, ?)' % self.tablename
         self.conn.executemany(UPDATE_ITEMS, items)

--- a/tests/test_temp_db.py
+++ b/tests/test_temp_db.py
@@ -72,12 +72,12 @@ class TempSqliteDictTest(TestCaseBackport):
     def test_update_records(self):
         ''' test_update_records
         '''
-        self.d.update(p='x', q='y', r='z')
-        self.assertEqual(len(self.d), 3)
+        self.d.update([('v', 'w')], p='x', q='y', r='z')
+        self.assertEqual(len(self.d), 4)
         # As far as I know dicts does not need to return
         # the elements in a specified order (sort() is required )
-        self.assertEqual(sorted(self.d.items()), sorted([('q', 'y'), ('p', 'x'), ('r', 'z')]))
-        self.assertEqual(sorted(list(self.d)), sorted(['q', 'p', 'r']))
+        self.assertEqual(sorted(self.d.items()), sorted([('q', 'y'), ('p', 'x'), ('r', 'z'), ('v', 'w')]))
+        self.assertEqual(sorted(list(self.d)), sorted(['q', 'p', 'r', 'v']))
 
     def test_handling_errors(self):
         ''' test_handling_errors


### PR DESCRIPTION
When pickling using a sequence of 2-tuples
the values do not get pickled.
(see example in the failed build)